### PR TITLE
Feature/ocb 8905 investigate nextflow status delay

### DIFF
--- a/nextflow/command.py
+++ b/nextflow/command.py
@@ -278,11 +278,11 @@ def get_execution(execution_path, nextflow_command):
     return_code = get_file_text(os.path.join(execution_path, "rc.txt"))
     started = get_started_from_log(log)
     finished = get_finished_from_log(log)
-    print(f"Processed logs in {time.time() - start_time}s")
+    print(f"Processed logs in {time.time() - start_time:.3f}s")
 
     start_time = time.time()
     process_executions = get_process_executions(log, execution_path)
-    print(f"Got process executions in {time.time() - start_time}s")
+    print(f"Got process executions in {time.time() - start_time:.3f}s")
     command = sorted(nextflow_command.split(";"), key=len)[-1]
     command = re.sub(r">[a-zA-Z0-9\/-]+?stdout\.txt", "", command)
     command = re.sub(r"2>[a-zA-Z0-9\/-]+?stderr\.txt", "", command).strip()
@@ -302,7 +302,7 @@ def get_execution(execution_path, nextflow_command):
     start_time = time.time()
     for process_execution in execution.process_executions:
         process_execution.execution = execution
-    print(f"Associated process executions in {time.time() - start_time}s")
+    print(f"Associated process executions in {time.time() - start_time:.3f}s")
     return execution
 
 
@@ -346,7 +346,7 @@ def get_process_execution(process_id, path, log, execution_path):
         returncode = get_file_text(os.path.join(full_path, ".exitcode"))
         bash = get_file_text(os.path.join(full_path, ".command.sh"))
     print(
-        f"Got stdout stderr returncode for {process_id} in {time.time() - start_time}s"
+        f"Got stdout stderr returncode for {process_id} in {time.time() - start_time:.3f}s"
     )
 
     start_time = time.time()
@@ -354,7 +354,7 @@ def get_process_execution(process_id, path, log, execution_path):
     started = (get_process_start_from_log(log, process_id),)
     finished = (get_process_end_from_log(log, process_id),)
     status = (get_process_status_from_log(log, process_id),)
-    print(f"Parsed logs for {process_id} in {time.time() - start_time}s")
+    print(f"Parsed logs for {process_id} in {time.time() - start_time:.3f}s")
     return ProcessExecution(
         identifier=process_id,
         name=name,

--- a/nextflow/command.py
+++ b/nextflow/command.py
@@ -101,6 +101,7 @@ def _run(
         time.sleep(sleep)
         print("Get Execution")
         execution = get_execution(output_path or run_path, nextflow_command)
+        print("Finished Get Execution")
         if execution and poll:
             yield execution
         process_finished = not process or process.poll() is not None
@@ -267,6 +268,7 @@ def get_execution(execution_path, nextflow_command):
     :rtype: ``nextflow.models.Execution``"""
 
     print("Doing get execution stuff")
+    print("Getting log, stdout, stderr, return code")
     log = get_file_text(os.path.join(execution_path, ".nextflow.log"))
     if not log:
         return
@@ -293,6 +295,7 @@ def get_execution(execution_path, nextflow_command):
         process_executions=process_executions,
     )
     for process_execution in execution.process_executions:
+        print("I'm in another loop. Confused what this does.")
         process_execution.execution = execution
     return execution
 
@@ -304,12 +307,15 @@ def get_process_executions(log, execution_path):
     :param str execution_path: the location of the execution.
     :rtype: ``list`` of ``nextflow.models.ProcessExecution``"""
 
+    print("Getting list of process executions")
     process_ids = re.findall(
         r"\[([a-f,0-9]{2}/[a-f,0-9]{6})\] Submitted process", log, flags=re.MULTILINE
     )
+    print(f"Process ids {process_ids}")
     process_executions = []
     process_ids_to_paths = get_process_ids_to_paths(process_ids, execution_path)
     for process_id in process_ids:
+        print("I'm in a loop, creating a list... suspicious")
         path = process_ids_to_paths.get(process_id, "")
         process_executions.append(
             get_process_execution(process_id, path, log, execution_path)

--- a/nextflow/command.py
+++ b/nextflow/command.py
@@ -354,6 +354,9 @@ def get_process_execution(process_id, path, log, execution_path):
     started = (get_process_start_from_log(log, process_id),)
     finished = (get_process_end_from_log(log, process_id),)
     status = (get_process_status_from_log(log, process_id),)
+    print(
+        f"PID {process_id} {name} started: {started} finished: {finished} status: {status}"
+    )
     print(f"Parsed logs for {process_id} in {time.time() - start_time:.3f}s")
     return ProcessExecution(
         identifier=process_id,

--- a/nextflow/command.py
+++ b/nextflow/command.py
@@ -98,11 +98,8 @@ def _run(
         )
     execution = None
     while True:
-        print("Sleeping")
         time.sleep(sleep)
-        print("Get Execution")
         execution = get_execution(output_path or run_path, nextflow_command)
-        print("Finished Get Execution")
         if execution and poll:
             yield execution
         process_finished = not process or process.poll() is not None
@@ -267,9 +264,6 @@ def get_execution(execution_path, nextflow_command):
     :param str execution_path: the location of the execution.
     :param str nextflow_command: the command used to run the pipeline.
     :rtype: ``nextflow.models.Execution``"""
-
-    print("Starting Get Execution...")
-    start_time = time.time()
     log = get_file_text(os.path.join(execution_path, ".nextflow.log"))
     if not log:
         return
@@ -279,11 +273,8 @@ def get_execution(execution_path, nextflow_command):
     return_code = get_file_text(os.path.join(execution_path, "rc.txt"))
     started = get_started_from_log(log)
     finished = get_finished_from_log(log)
-    print(f"Processed logs in {time.time() - start_time:.3f}s")
 
-    start_time = time.time()
     process_executions = get_process_executions(log, execution_path)
-    print(f"Got process executions in {time.time() - start_time:.3f}s")
     command = sorted(nextflow_command.split(";"), key=len)[-1]
     command = re.sub(r">[a-zA-Z0-9\/-]+?stdout\.txt", "", command)
     command = re.sub(r"2>[a-zA-Z0-9\/-]+?stderr\.txt", "", command).strip()
@@ -303,7 +294,6 @@ def get_execution(execution_path, nextflow_command):
     start_time = time.time()
     for process_execution in execution.process_executions:
         process_execution.execution = execution
-    print(f"Associated process executions in {time.time() - start_time:.3f}s")
     return execution
 
 
@@ -317,7 +307,6 @@ def get_process_executions(log, execution_path):
     process_ids = re.findall(
         r"\[([a-f,0-9]{2}/[a-f,0-9]{6})\] Submitted process", log, flags=re.MULTILINE
     )
-    print(f"Process ids {process_ids}")
     process_executions = []
     process_ids_to_paths = get_process_ids_to_paths(process_ids, execution_path)
     process_info = collect_process_info_from_logs(log, process_ids)
@@ -347,17 +336,10 @@ def get_process_execution(process_id, path, process_info, execution_path):
         returncode = get_file_text(os.path.join(full_path, ".exitcode"))
         bash = get_file_text(os.path.join(full_path, ".command.sh"))
 
-    # name = get_process_name_from_log(log, process_id)
-    # started = (get_process_start_from_log(log, process_id),)
-    # finished = (get_process_end_from_log(log, process_id),)
-    # status = (get_process_status_from_log(log, process_id),)
     name = process_info[process_id]["name"]
     started = (process_info[process_id]["start"],)
     finished = (process_info[process_id]["end"],)
     status = (process_info[process_id]["status"],)
-    print(
-        f"PID {process_id} {name} started: {started} finished: {finished} status: {status}"
-    )
     return ProcessExecution(
         identifier=process_id,
         name=name,

--- a/nextflow/command.py
+++ b/nextflow/command.py
@@ -10,12 +10,13 @@ from nextflow.log import (
     get_process_name_from_log,
     get_process_start_from_log,
     get_process_end_from_log,
-    get_process_status_from_log
+    get_process_status_from_log,
 )
+
 
 def run(*args, **kwargs):
     """Runs a pipeline and returns the execution.
-    
+
     :param str pipeline_path: the absolute path to the pipeline .nf file.
     :param str run_path: the location to run the pipeline in.
     :param str output_path: the location to store the output in.
@@ -36,7 +37,7 @@ def run(*args, **kwargs):
 def run_and_poll(*args, **kwargs):
     """Runs a pipeline and polls it for updates. Yields the execution after each
     update.
-    
+
     :param str pipeline_path: the absolute path to the pipeline .nf file.
     :param str run_path: the location to run the pipeline in.
     :param str output_path: the location to store the output in.
@@ -57,36 +58,73 @@ def run_and_poll(*args, **kwargs):
 
 
 def _run(
-        pipeline_path, poll=False, run_path=None, output_path=None, runner=None,
-        version=None, configs=None, params=None, profiles=None, timezone=None,
-        report=None, timeline=None, dag=None, sleep=1
+    pipeline_path,
+    poll=False,
+    run_path=None,
+    output_path=None,
+    runner=None,
+    version=None,
+    configs=None,
+    params=None,
+    profiles=None,
+    timezone=None,
+    report=None,
+    timeline=None,
+    dag=None,
+    sleep=1,
 ):
-    if not run_path: run_path = os.path.abspath(".")
+    if not run_path:
+        run_path = os.path.abspath(".")
     nextflow_command = make_nextflow_command(
-        run_path, output_path, pipeline_path, version, configs, params,
-        profiles, timezone, report, timeline, dag
+        run_path,
+        output_path,
+        pipeline_path,
+        version,
+        configs,
+        params,
+        profiles,
+        timezone,
+        report,
+        timeline,
+        dag,
     )
     if runner:
         process = None
         runner(nextflow_command)
     else:
         process = subprocess.Popen(
-            nextflow_command, universal_newlines=True, shell=True        
+            nextflow_command, universal_newlines=True, shell=True
         )
     execution = None
     while True:
+        print("Sleeping")
         time.sleep(sleep)
+        print("Get Execution")
         execution = get_execution(output_path or run_path, nextflow_command)
-        if execution and poll: yield execution
+        if execution and poll:
+            yield execution
         process_finished = not process or process.poll() is not None
         if execution and execution.return_code and process_finished:
-            if not poll: yield execution
+            if not poll:
+                yield execution
             break
 
 
-def make_nextflow_command(run_path, output_path, pipeline_path, version, configs, params, profiles, timezone, report, timeline, dag):
+def make_nextflow_command(
+    run_path,
+    output_path,
+    pipeline_path,
+    version,
+    configs,
+    params,
+    profiles,
+    timezone,
+    report,
+    timeline,
+    dag,
+):
     """Generates the `nextflow run` commmand.
-    
+
     :param str run_path: the location to run the pipeline in.
     :param str output_path: the location to store the output in.
     :param str pipeline_path: the absolute path to the pipeline .nf file.
@@ -101,17 +139,23 @@ def make_nextflow_command(run_path, output_path, pipeline_path, version, configs
     :rtype: ``str``"""
 
     env = make_nextflow_command_env_string(version, timezone, output_path)
-    if env: env += " "
+    if env:
+        env += " "
     nf = "nextflow -Duser.country=US"
     log = make_nextflow_command_log_string(output_path)
-    if log: log += " "
+    if log:
+        log += " "
     configs = make_nextflow_command_config_string(configs)
-    if configs: configs += " "
+    if configs:
+        configs += " "
     params = make_nextflow_command_params_string(params)
     profiles = make_nextflow_command_profiles_string(profiles)
     reports = make_reports_string(output_path, report, timeline, dag)
-    command = f"{env}{nf} {log}{configs}run {pipeline_path} {params} {profiles} {reports}"
-    if run_path: command = f"cd {run_path}; {command}"
+    command = (
+        f"{env}{nf} {log}{configs}run {pipeline_path} {params} {profiles} {reports}"
+    )
+    if run_path:
+        command = f"cd {run_path}; {command}"
     prefix = (str(output_path) + os.path.sep) if output_path else ""
     command = command.rstrip() + f" >{prefix}"
     command += f"stdout.txt 2>{prefix}"
@@ -122,38 +166,43 @@ def make_nextflow_command(run_path, output_path, pipeline_path, version, configs
 def make_nextflow_command_env_string(version, timezone, output_path):
     """Creates the environment variable setting portion of the nextflow run
     command string.
-    
+
     :param str version: the nextflow version to use.
     :param str timezone: the timezone to use.
     :param str output_path: the location to store the output in.
     :rtype: ``str``"""
 
     env = {"NXF_ANSI_LOG": "false"}
-    if version: env["NXF_VER"] = version
-    if timezone: env["TZ"] = timezone
-    if output_path: env["NXF_WORK"] = os.path.join(output_path, "work")
+    if version:
+        env["NXF_VER"] = version
+    if timezone:
+        env["TZ"] = timezone
+    if output_path:
+        env["NXF_WORK"] = os.path.join(output_path, "work")
     return " ".join([f"{k}={v}" for k, v in env.items()])
 
 
 def make_nextflow_command_log_string(output_path):
     """Creates the log setting portion of the nextflow run command string.
-    
+
     :param str output_path: the location to store the output in.
     :rtype: ``str``"""
 
-    if not output_path: return ""
+    if not output_path:
+        return ""
     return f"-log '{os.path.join(output_path, '.nextflow.log')}'"
 
 
 def make_nextflow_command_config_string(configs):
     """Creates the config setting portion of the nextflow run command string.
     Absolute paths are recommended.
-    
+
     :param str version: the nextflow version to use.
     :rtype: ``str``"""
 
-    if configs is None: configs = []
-    return " ".join(f"-c \"{c}\"" for c in configs)
+    if configs is None:
+        configs = []
+    return " ".join(f'-c "{c}"' for c in configs)
 
 
 def make_nextflow_command_params_string(params):
@@ -162,12 +211,13 @@ def make_nextflow_command_params_string(params):
     :param dict params: the parameters to pass.
     :rtype: ``str``"""
 
-    if not params: return ""
+    if not params:
+        return ""
     param_list = []
     for key, value in params.items():
         if not value:
             param_list.append(f"--{key}=")
-        elif value[0] in "'\"": 
+        elif value[0] in "'\"":
             param_list.append(f"--{key}={value}")
         else:
             param_list.append(f"--{key}='{value}'")
@@ -176,17 +226,18 @@ def make_nextflow_command_params_string(params):
 
 def make_nextflow_command_profiles_string(profiles):
     """Creates the profile setting portion of the nextflow run command string.
-    
+
     :param list profiles: any profiles to be applied.
     :rtype: ``str``"""
 
-    if not profiles: return ""
-    return ("-profile " + ",".join(profiles))
+    if not profiles:
+        return ""
+    return "-profile " + ",".join(profiles)
 
 
 def make_reports_string(output_path, report, timeline, dag):
     """Creates the report setting portion of the nextflow run command string.
-    
+
     :param str output_path: the location to store the output in.
     :param str report: the filename to use for the execution report.
     :param str timeline: the filename to use for the timeline report.
@@ -194,9 +245,12 @@ def make_reports_string(output_path, report, timeline, dag):
     :rtype: ``str``"""
 
     params = []
-    if report: params.append(f"-with-report {report}")
-    if timeline: params.append(f"-with-timeline {timeline}")
-    if dag: params.append(f"-with-dag {dag}")
+    if report:
+        params.append(f"-with-report {report}")
+    if timeline:
+        params.append(f"-with-timeline {timeline}")
+    if dag:
+        params.append(f"-with-dag {dag}")
     if output_path:
         for i, param in enumerate(params):
             words = param.split(" ")
@@ -207,13 +261,15 @@ def make_reports_string(output_path, report, timeline, dag):
 
 def get_execution(execution_path, nextflow_command):
     """Creates an execution object from a location.
-    
+
     :param str execution_path: the location of the execution.
     :param str nextflow_command: the command used to run the pipeline.
     :rtype: ``nextflow.models.Execution``"""
 
+    print("Doing get execution stuff")
     log = get_file_text(os.path.join(execution_path, ".nextflow.log"))
-    if not log: return
+    if not log:
+        return
     identifier = m[1] if (m := re.search(r"\[([a-z]+_[a-z]+)\]", log)) else ""
     stdout = get_file_text(os.path.join(execution_path, "stdout.txt"))
     stderr = get_file_text(os.path.join(execution_path, "stderr.txt"))
@@ -225,9 +281,15 @@ def get_execution(execution_path, nextflow_command):
     command = re.sub(r">[a-zA-Z0-9\/-]+?stdout\.txt", "", command)
     command = re.sub(r"2>[a-zA-Z0-9\/-]+?stderr\.txt", "", command).strip()
     execution = Execution(
-        identifier=identifier, stdout=stdout, stderr=stderr,
-        return_code=return_code.strip(), started=started, finished=finished,
-        command=command, log=log, path=execution_path,
+        identifier=identifier,
+        stdout=stdout,
+        stderr=stderr,
+        return_code=return_code.strip(),
+        started=started,
+        finished=finished,
+        command=command,
+        log=log,
+        path=execution_path,
         process_executions=process_executions,
     )
     for process_execution in execution.process_executions:
@@ -237,34 +299,33 @@ def get_execution(execution_path, nextflow_command):
 
 def get_process_executions(log, execution_path):
     """Creates a list of process executions from a log.
-    
+
     :param str log: the log text.
     :param str execution_path: the location of the execution.
     :rtype: ``list`` of ``nextflow.models.ProcessExecution``"""
 
     process_ids = re.findall(
-        r"\[([a-f,0-9]{2}/[a-f,0-9]{6})\] Submitted process",
-        log, flags=re.MULTILINE
+        r"\[([a-f,0-9]{2}/[a-f,0-9]{6})\] Submitted process", log, flags=re.MULTILINE
     )
     process_executions = []
     process_ids_to_paths = get_process_ids_to_paths(process_ids, execution_path)
     for process_id in process_ids:
         path = process_ids_to_paths.get(process_id, "")
-        process_executions.append(get_process_execution(
-            process_id, path, log, execution_path
-        ))
+        process_executions.append(
+            get_process_execution(process_id, path, log, execution_path)
+        )
     return process_executions
 
 
 def get_process_execution(process_id, path, log, execution_path):
     """Creates a process execution from a log and its ID.
-    
+
     :param str process_id: the ID of the process.
     :param str path: the path of the process.
     :param str log: the log text.
     :param str execution_path: the location of the execution.
     :rtype: ``nextflow.models.ProcessExecution``"""
-    
+
     stdout, stderr, returncode, bash = "", "", "", ""
     if path:
         full_path = os.path.join(execution_path, "work", path)
@@ -274,9 +335,13 @@ def get_process_execution(process_id, path, log, execution_path):
         bash = get_file_text(os.path.join(full_path, ".command.sh"))
     name = get_process_name_from_log(log, process_id)
     return ProcessExecution(
-        identifier=process_id, name=name,
-        process=name[:name.find("(") - 1] if "(" in name else name,
-        path=path, stdout=stdout, stderr=stderr, return_code=returncode,
+        identifier=process_id,
+        name=name,
+        process=name[: name.find("(") - 1] if "(" in name else name,
+        path=path,
+        stdout=stdout,
+        stderr=stderr,
+        return_code=returncode,
         bash=bash,
         started=get_process_start_from_log(log, process_id),
         finished=get_process_end_from_log(log, process_id),

--- a/nextflow/command.py
+++ b/nextflow/command.py
@@ -324,7 +324,7 @@ def get_process_executions(log, execution_path):
     for process_id in process_ids:
         path = process_ids_to_paths.get(process_id, "")
         process_executions.append(
-            get_process_execution(process_id, path, log, execution_path)
+            get_process_execution(process_id, path, process_info, execution_path)
         )
     return process_executions
 
@@ -334,7 +334,7 @@ def get_process_execution(process_id, path, process_info, execution_path):
 
     :param str process_id: the ID of the process.
     :param str path: the path of the process.
-    :param str process_info: dictionary of process_id information from the log file
+    :param dict process_info: dictionary of process_id information from the log file
     :param str execution_path: the location of the execution.
     :rtype: ``nextflow.models.ProcessExecution``"""
 

--- a/nextflow/log.py
+++ b/nextflow/log.py
@@ -1,84 +1,94 @@
 import re
 from datetime import datetime
 
+
 def get_started_from_log(log):
     """Gets the time the pipeline was started from the log file.
-    
+
     :param str log: the contents of the log file.
     :rtype: ``datetime.datetime``"""
 
-    if not log: return None
+    if not log:
+        return None
     lines = log.splitlines()
-    if not lines: return None
+    if not lines:
+        return None
     return get_datetime_from_line(lines[0])
 
 
 def get_finished_from_log(log):
     """Gets the time the pipeline ended from the log file.
-    
+
     :param str log: the contents of the log file.
     :rtype: ``datetime.datetime``"""
 
-    if not log: return None
+    if not log:
+        return None
     lines = log.splitlines()
     if log_is_finished(log):
         for line in reversed(lines):
             dt = get_datetime_from_line(line)
-            if dt: return dt
+            if dt:
+                return dt
 
 
 def log_is_finished(log):
     """Checks if the log file indicates the pipeline has finished.
-    
+
     :param str log: the contents of the log file.
     :rtype: ``bool``"""
 
-    if not log: return False
+    if not log:
+        return False
     lines = log.strip().splitlines()
-    if lines[-1].endswith(" - > Execution complete -- Goodbye"): return True
+    if lines[-1].endswith(" - > Execution complete -- Goodbye"):
+        return True
     if lines[-1].startswith("    at ") or lines[-1].startswith("\tat "):
         last_unindented = [l for l in lines if not l.startswith("	at ")][-1]
-        if "Exception" in last_unindented: return True
+        if "Exception" in last_unindented:
+            return True
     return False
 
 
 def get_datetime_from_line(line):
     """Gets the datetime from a line of the log file.
-    
+
     :param str line: a line from the log file.
     :rtype: ``datetime.datetime``"""
 
     year = datetime.now().year
-    if (m := re.search(r"[A-Z][a-z]{2}-\d{1,2} \d{2}:\d{2}:\d{2}\.\d{3}", line)):
+    if m := re.search(r"[A-Z][a-z]{2}-\d{1,2} \d{2}:\d{2}:\d{2}\.\d{3}", line):
         return datetime.strptime(f"{year}-{m.group(0)}", "%Y-%b-%d %H:%M:%S.%f")
     return None
 
 
 def get_process_name_from_log(log, process_id):
     """Gets a process's name from the .nextflow.log file, given its unique ID.
-    
+
     :param str log: The text of the log file.
     :param str process_id: The process's ID (eg. '1a/234bcd').
     :rtype: ``str``"""
 
-    escaped_id = process_id.replace('/', '\\/')
+    escaped_id = process_id.replace("/", "\\/")
     match = re.search(f"\\[{escaped_id}\\] Submitted process > (.+)", log)
-    if match: return match[1]
+    if match:
+        return match[1]
 
 
 def get_process_start_from_log(log, process_id):
     """Gets a process's start time from the .nextflow.log file as a datetime,
     given its unique ID, if it has started.
-    
+
     :param str log: The text of the log file.
     :param str process_id: The process's ID (eg. '1a/234bcd').
     :rtype: ``datetime``"""
 
-    escaped_id = process_id.replace('/', '\\/')
+    escaped_id = process_id.replace("/", "\\/")
     match = re.search(
         f"(...-\d+ \d+:\d+:\d+\.\d+).+\\[{escaped_id}\\] Submitted process", log
     )
-    if not match: return
+    if not match:
+        return
     year = datetime.now().year
     return datetime.strptime(f"{year}-{match[1]}", "%Y-%b-%d %H:%M:%S.%f")
 
@@ -86,16 +96,15 @@ def get_process_start_from_log(log, process_id):
 def get_process_end_from_log(log, process_id):
     """Gets a process's end time from the .nextflow.log file as a datetime,
     given its unique ID, if it has finshed.
-    
+
     :param str log: The text of the log file.
     :param str process_id: The process's ID (eg. '1a/234bcd').
     :rtype: ``datetime``"""
 
-    escaped_id = process_id.replace('/', '\\/')
-    match = re.search(
-        f"(...-\d+ \d+:\d+:\d+\.\d+).+Task completed.+{escaped_id}", log
-    )
-    if not match: return
+    escaped_id = process_id.replace("/", "\\/")
+    match = re.search(f"(...-\d+ \d+:\d+:\d+\.\d+).+Task completed.+{escaped_id}", log)
+    if not match:
+        return
     year = datetime.now().year
     return datetime.strptime(f"{year}-{match[1]}", "%Y-%b-%d %H:%M:%S.%f")
 
@@ -103,15 +112,75 @@ def get_process_end_from_log(log, process_id):
 def get_process_status_from_log(log, process_id):
     """Gets a process's status (COMPLETED, ERROR etc.) from the .nextflow.log
     file, given its unique ID. If it's still running, '-' is returned.
-    
+
     :param str log: The text of the log file.
     :param str process_id: The process's ID (eg. '1a/234bcd').
     :rtype: ``string``"""
 
-    escaped_id = process_id.replace('/', '\\/')
+    escaped_id = process_id.replace("/", "\\/")
     match = re.search(
         f".+Task completed.+status: ([A-Z]+).+exit: (.+?);.+{escaped_id}", log
     )
-    if not match: return "-"
-    if match[2].isdigit() and match[2] != "0": return "FAILED"
+    if not match:
+        return "-"
+    if match[2].isdigit() and match[2] != "0":
+        return "FAILED"
     return match[1]
+
+
+def collect_process_info_from_logs(log, process_ids):
+    year = datetime.now().year
+    process_info = {}
+    for pid in process_ids:
+        process_info[pid] = {}
+        process_info[pid]["name"] = None
+        process_info[pid]["start"] = None
+        process_info[pid]["end"] = None
+        process_info[pid]["status"] = "-"
+
+    for line in log.splitlines():
+        line = line.strip()
+
+        if "Submitted process" in line:
+            # Example logline:
+            # Jan-17 17:01:48.846 [AWSBatch-executor-163] INFO  nextflow.Session - [f4/a0d5ad] Submitted process > SINGLETS (223)
+            log_pattern = r"(?P<timestamp>\w{3}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}) \[.*?\] INFO  nextflow\.Session - \[(?P<id>[\w/]+)\] Submitted process > (?P<name>.+)"
+            match = re.match(log_pattern, line)
+            if match:
+                start = datetime.strptime(
+                    f"{year}-{match.group('timestamp')}", "%Y-%b-%d %H:%M:%S.%f"
+                )
+                id = match.group("id")
+                name = match.group("name")
+
+                if id in process_info:
+                    process_info[id]["name"] = name
+                    process_info[id]["start"] = start
+
+        elif "Task completed" in line:
+            # Example logline:
+            # Jan-17 17:01:49.519 [Task monitor] DEBUG n.processor.TaskPollingMonitor - Task completed > TaskHandler[id: 938; name: COMPENSATE (228); status: COMPLETED; exit: 0; error: -; workDir: s3://ozette-temp/nextflow/work/5d/ce81938befec30ba97b2788592b055]
+            log_pattern = (
+                r"(?P<timestamp>\w{3}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}) .*?"
+                r"Task completed > TaskHandler\[.*?status: (?P<status>\w+); "
+                r"exit: (?P<exit_code>\d+); .*?workDir: .*?/work/(?P<id>[\w/]{9})"
+            )
+
+            match = re.match(log_pattern, line)
+            if match:
+                # Extract the components
+                end = datetime.strptime(
+                    f"{year}-{match.group('timestamp')}", "%Y-%b-%d %H:%M:%S.%f"
+                )
+                status = match.group("status")
+                exit_code = match.group("exit_code")
+                id = match.group("id")
+                if id in process_info:
+                    process_info[id]["name"] = name
+                    process_info[id]["end"] = end
+                    if exit_code.isdigit() and exit_code != "0":
+                        process_info[id]["status"] = "FAILED"
+                    else:
+                        process_info[id]["status"] = status
+
+    return process_info

--- a/tests/unit/test_command.py
+++ b/tests/unit/test_command.py
@@ -3,23 +3,33 @@ from unittest.mock import patch, Mock, MagicMock
 from nextflow.command import *
 from nextflow.command import _run
 
-class RunTests(TestCase):
 
+class RunTests(TestCase):
     @patch("nextflow.command.make_nextflow_command")
     @patch("subprocess.Popen")
     @patch("time.sleep")
     @patch("nextflow.command.get_execution")
     def test_can_run_with_default_values(self, mock_ex, mock_sleep, mock_run, mock_nc):
         executions = list(_run("main.nf"))
-        mock_nc.assert_called_with(os.path.abspath("."), None, "main.nf", None, None, None, None, None, None, None, None)
+        mock_nc.assert_called_with(
+            os.path.abspath("."),
+            None,
+            "main.nf",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
         mock_run.assert_called_with(
-            mock_nc.return_value,
-            universal_newlines=True, shell=True
+            mock_nc.return_value, universal_newlines=True, shell=True
         )
         mock_sleep.assert_called_with(1)
         mock_ex.assert_called_with(os.path.abspath("."), mock_nc.return_value)
         self.assertEqual(executions, [mock_ex.return_value])
-    
 
     @patch("nextflow.command.make_nextflow_command")
     @patch("subprocess.Popen")
@@ -28,22 +38,43 @@ class RunTests(TestCase):
     def test_can_run_with_custom_values(self, mock_ex, mock_sleep, mock_run, mock_nc):
         mock_executions = [Mock(return_code=""), Mock(return_code="0")]
         mock_ex.side_effect = [None, *mock_executions]
-        executions = list(_run(
-            "main.nf", run_path="/exdir", output_path="/out", version="21.10", configs=["conf1"],
-            params={"param": "2"}, profiles=["docker"], timezone="UTC", report="report.html",
-            timeline="time.html", dag="dag.html", sleep=4
-        ))
-        mock_nc.assert_called_with("/exdir", "/out", "main.nf", "21.10", ["conf1"], {"param": "2"}, ["docker"], "UTC", "report.html", "time.html", "dag.html")
+        executions = list(
+            _run(
+                "main.nf",
+                run_path="/exdir",
+                output_path="/out",
+                version="21.10",
+                configs=["conf1"],
+                params={"param": "2"},
+                profiles=["docker"],
+                timezone="UTC",
+                report="report.html",
+                timeline="time.html",
+                dag="dag.html",
+                sleep=4,
+            )
+        )
+        mock_nc.assert_called_with(
+            "/exdir",
+            "/out",
+            "main.nf",
+            "21.10",
+            ["conf1"],
+            {"param": "2"},
+            ["docker"],
+            "UTC",
+            "report.html",
+            "time.html",
+            "dag.html",
+        )
         mock_run.assert_called_with(
-            mock_nc.return_value,
-            universal_newlines=True, shell=True
+            mock_nc.return_value, universal_newlines=True, shell=True
         )
         mock_sleep.assert_called_with(4)
         self.assertEqual(mock_sleep.call_count, 3)
         mock_ex.assert_called_with("/out", mock_nc.return_value)
         self.assertEqual(mock_ex.call_count, 3)
         self.assertEqual(executions, [mock_executions[1]])
-
 
     @patch("nextflow.command.make_nextflow_command")
     @patch("subprocess.Popen")
@@ -54,17 +85,27 @@ class RunTests(TestCase):
         mock_executions = [Mock(finished=False), Mock(finished=True)]
         mock_ex.side_effect = [None, *mock_executions]
         executions = list(_run("main.nf", poll=True))
-        mock_nc.assert_called_with(os.path.abspath("."), None, "main.nf", None, None, None, None, None, None, None, None)
+        mock_nc.assert_called_with(
+            os.path.abspath("."),
+            None,
+            "main.nf",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
         mock_run.assert_called_with(
-            mock_nc.return_value,
-            universal_newlines=True, shell=True
+            mock_nc.return_value, universal_newlines=True, shell=True
         )
         mock_sleep.assert_called_with(1)
         self.assertEqual(mock_sleep.call_count, 3)
         mock_ex.assert_called_with(os.path.abspath("."), mock_nc.return_value)
         self.assertEqual(mock_ex.call_count, 3)
         self.assertEqual(executions, mock_executions)
-    
 
     @patch("nextflow.command.make_nextflow_command")
     @patch("subprocess.Popen")
@@ -73,13 +114,24 @@ class RunTests(TestCase):
     def test_can_run_with_custom_runner(self, mock_ex, mock_sleep, mock_run, mock_nc):
         runner = MagicMock()
         executions = list(_run("main.nf", runner=runner))
-        mock_nc.assert_called_with(os.path.abspath("."), None, "main.nf", None, None, None, None, None, None, None, None)
+        mock_nc.assert_called_with(
+            os.path.abspath("."),
+            None,
+            "main.nf",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
         self.assertFalse(mock_run.called)
         runner.assert_called_with(mock_nc.return_value)
         mock_sleep.assert_called_with(1)
         mock_ex.assert_called_with(os.path.abspath("."), mock_nc.return_value)
         self.assertEqual(executions, [mock_ex.return_value])
-    
 
     @patch("nextflow.command._run")
     def test_can_run_without_poll(self, mock_run):
@@ -87,7 +139,6 @@ class RunTests(TestCase):
         execution = run(1, 2, a=3)
         self.assertEqual(execution, mock_run.return_value[0])
         mock_run.assert_called_with(1, 2, a=3, poll=False)
-    
 
     @patch("nextflow.command._run")
     def test_can_run_with_poll(self, mock_run):
@@ -97,30 +148,44 @@ class RunTests(TestCase):
         mock_run.assert_called_with(1, 2, a=3, poll=True)
 
 
-
 class NextflowCommandTests(TestCase):
-
     @patch("nextflow.command.make_nextflow_command_env_string")
     @patch("nextflow.command.make_nextflow_command_log_string")
     @patch("nextflow.command.make_nextflow_command_config_string")
     @patch("nextflow.command.make_nextflow_command_params_string")
     @patch("nextflow.command.make_nextflow_command_profiles_string")
     @patch("nextflow.command.make_reports_string")
-    def test_can_get_full_nextflow_command(self, mock_report, mock_prof, mock_params, mock_conf, mock_log, mock_env):
+    def test_can_get_full_nextflow_command(
+        self, mock_report, mock_prof, mock_params, mock_conf, mock_log, mock_env
+    ):
         mock_env.return_value = "A=B C=D"
         mock_log.return_value = "-log '.nextflow.log'"
         mock_conf.return_value = "-c conf1 -c conf2"
         mock_params.return_value = "--p1=10 --p2=20"
         mock_prof.return_value = "-profile docker,test"
         mock_report.return_value = "--dag.html"
-        command = make_nextflow_command("/exdir", "/out", "main.nf", "21.10", ["conf1"], {"param": "2"}, ["docker"], "UTC", "report.html", "time.html", "dag.html")
+        command = make_nextflow_command(
+            "/exdir",
+            "/out",
+            "main.nf",
+            "21.10",
+            ["conf1"],
+            {"param": "2"},
+            ["docker"],
+            "UTC",
+            "report.html",
+            "time.html",
+            "dag.html",
+        )
         mock_env.assert_called_with("21.10", "UTC", "/out")
         mock_conf.assert_called_with(["conf1"])
         mock_params.assert_called_with({"param": "2"})
         mock_prof.assert_called_with(["docker"])
         mock_report.assert_called_with("/out", "report.html", "time.html", "dag.html")
-        self.assertEqual(command, "cd /exdir; A=B C=D nextflow -Duser.country=US -log '.nextflow.log' -c conf1 -c conf2 run main.nf --p1=10 --p2=20 -profile docker,test --dag.html >/out/stdout.txt 2>/out/stderr.txt; echo $? >/out/rc.txt")
-    
+        self.assertEqual(
+            command,
+            "cd /exdir; A=B C=D nextflow -Duser.country=US -log '.nextflow.log' -c conf1 -c conf2 run main.nf --p1=10 --p2=20 -profile docker,test --dag.html >/out/stdout.txt 2>/out/stderr.txt; echo $? >/out/rc.txt",
+        )
 
     @patch("nextflow.command.make_nextflow_command_env_string")
     @patch("nextflow.command.make_nextflow_command_log_string")
@@ -128,151 +193,182 @@ class NextflowCommandTests(TestCase):
     @patch("nextflow.command.make_nextflow_command_params_string")
     @patch("nextflow.command.make_nextflow_command_profiles_string")
     @patch("nextflow.command.make_reports_string")
-    def test_can_get_minimal_nextflow_command(self, mock_report, mock_prof, mock_params, mock_conf, mock_log, mock_env):
+    def test_can_get_minimal_nextflow_command(
+        self, mock_report, mock_prof, mock_params, mock_conf, mock_log, mock_env
+    ):
         mock_env.return_value = ""
         mock_log.return_value = ""
         mock_conf.return_value = ""
         mock_params.return_value = ""
         mock_prof.return_value = ""
         mock_report.return_value = ""
-        command = make_nextflow_command(None, None, "main.nf", "21.10", ["conf1"], {"param": "2"}, ["docker"], None, None, None, None)
+        command = make_nextflow_command(
+            None,
+            None,
+            "main.nf",
+            "21.10",
+            ["conf1"],
+            {"param": "2"},
+            ["docker"],
+            None,
+            None,
+            None,
+            None,
+        )
         mock_env.assert_called_with("21.10", None, None)
         mock_conf.assert_called_with(["conf1"])
         mock_params.assert_called_with({"param": "2"})
         mock_prof.assert_called_with(["docker"])
         mock_report.assert_called_with(None, None, None, None)
-        self.assertEqual(command, "nextflow -Duser.country=US run main.nf >stdout.txt 2>stderr.txt; echo $? >rc.txt")
-
+        self.assertEqual(
+            command,
+            "nextflow -Duser.country=US run main.nf >stdout.txt 2>stderr.txt; echo $? >rc.txt",
+        )
 
 
 class EnvStringTests(TestCase):
-
     def test_can_get_env_without_args(self):
-        self.assertEqual(make_nextflow_command_env_string(None, None, None), "NXF_ANSI_LOG=false")
-
+        self.assertEqual(
+            make_nextflow_command_env_string(None, None, None), "NXF_ANSI_LOG=false"
+        )
 
     def test_can_get_env_with_version(self):
-        self.assertEqual(make_nextflow_command_env_string("22.1", None, None), "NXF_ANSI_LOG=false NXF_VER=22.1")
-    
+        self.assertEqual(
+            make_nextflow_command_env_string("22.1", None, None),
+            "NXF_ANSI_LOG=false NXF_VER=22.1",
+        )
 
     def test_can_get_env_with_timezone(self):
-        self.assertEqual(make_nextflow_command_env_string(None, "UTC", None), "NXF_ANSI_LOG=false TZ=UTC")
-    
+        self.assertEqual(
+            make_nextflow_command_env_string(None, "UTC", None),
+            "NXF_ANSI_LOG=false TZ=UTC",
+        )
 
     def test_can_get_env_with_work_location(self):
-        self.assertEqual(make_nextflow_command_env_string(None, None, "/out"), "NXF_ANSI_LOG=false NXF_WORK=/out/work")
-
+        self.assertEqual(
+            make_nextflow_command_env_string(None, None, "/out"),
+            "NXF_ANSI_LOG=false NXF_WORK=/out/work",
+        )
 
 
 class LogStringTests(TestCase):
-
     def test_can_handle_no_directory(self):
         self.assertEqual(make_nextflow_command_log_string(None), "")
-    
 
     def test_can_handle_directory(self):
-        self.assertEqual(make_nextflow_command_log_string("/out"), "-log '/out/.nextflow.log'")
-
+        self.assertEqual(
+            make_nextflow_command_log_string("/out"), "-log '/out/.nextflow.log'"
+        )
 
 
 class ConfigStringTests(TestCase):
-
     def test_can_handle_no_config(self):
         self.assertEqual(make_nextflow_command_config_string(None), "")
         self.assertEqual(make_nextflow_command_config_string([]), "")
-    
 
     def test_can_handle_config(self):
-        self.assertEqual(make_nextflow_command_config_string(["conf1", "conf2"]), '-c "conf1" -c "conf2"')
-
+        self.assertEqual(
+            make_nextflow_command_config_string(["conf1", "conf2"]),
+            '-c "conf1" -c "conf2"',
+        )
 
 
 class ParamsStringTests(TestCase):
-
     def test_can_handle_no_params(self):
         self.assertEqual(make_nextflow_command_params_string(None), "")
         self.assertEqual(make_nextflow_command_params_string({}), "")
-    
 
     def test_can_handle_params(self):
-        self.assertEqual(make_nextflow_command_params_string(
-            {"param": "2", "param2": "'3'", "param3": '"7"'}
-        ), "--param='2' --param2='3' --param3=\"7\""
-    )
-        
+        self.assertEqual(
+            make_nextflow_command_params_string(
+                {"param": "2", "param2": "'3'", "param3": '"7"'}
+            ),
+            "--param='2' --param2='3' --param3=\"7\"",
+        )
 
     def test_can_handle_params_with_empty_values(self):
-        self.assertEqual(make_nextflow_command_params_string(
-            {"param": "2", "param2": "",}
-        ), "--param='2' --param2="
-    )
-
+        self.assertEqual(
+            make_nextflow_command_params_string(
+                {
+                    "param": "2",
+                    "param2": "",
+                }
+            ),
+            "--param='2' --param2=",
+        )
 
 
 class ProfilesStringTests(TestCase):
-
     def test_can_handle_no_profiles(self):
         self.assertEqual(make_nextflow_command_profiles_string(None), "")
         self.assertEqual(make_nextflow_command_profiles_string([]), "")
-    
 
     def test_can_handle_profiles(self):
-        self.assertEqual(make_nextflow_command_profiles_string(["docker", "test"]), "-profile docker,test")
-
+        self.assertEqual(
+            make_nextflow_command_profiles_string(["docker", "test"]),
+            "-profile docker,test",
+        )
 
 
 class ReportsStringTests(TestCase):
-
     def test_can_handle_no_reports(self):
         self.assertEqual(make_reports_string(None, None, None, None), "")
-    
 
     def test_can_make_execution_report(self):
-        self.assertEqual(make_reports_string(None, "report.html", None, None), "-with-report report.html")
-    
+        self.assertEqual(
+            make_reports_string(None, "report.html", None, None),
+            "-with-report report.html",
+        )
 
     def test_can_make_timeline_report(self):
-        self.assertEqual(make_reports_string(None, None, "time.html", None), "-with-timeline time.html")
-    
+        self.assertEqual(
+            make_reports_string(None, None, "time.html", None),
+            "-with-timeline time.html",
+        )
 
     def test_can_make_dag_report(self):
-        self.assertEqual(make_reports_string(None, None, None, "dag.html"), "-with-dag dag.html")
-    
+        self.assertEqual(
+            make_reports_string(None, None, None, "dag.html"), "-with-dag dag.html"
+        )
 
     def test_can_make_full_report(self):
         self.assertEqual(
             make_reports_string(None, "report.html", "time.html", "dag.html"),
-            "-with-report report.html -with-timeline time.html -with-dag dag.html"
+            "-with-report report.html -with-timeline time.html -with-dag dag.html",
         )
-    
 
     def test_can_make_full_report_with_custom_location(self):
         self.assertEqual(
             make_reports_string("/out", "report.html", "time.html", "dag.html"),
-            "-with-report /out/report.html -with-timeline /out/time.html -with-dag /out/dag.html"
+            "-with-report /out/report.html -with-timeline /out/time.html -with-dag /out/dag.html",
         )
 
 
-
 class GetExecutionTests(TestCase):
-
     @patch("nextflow.command.get_file_text")
     @patch("nextflow.command.get_started_from_log")
     @patch("nextflow.command.get_finished_from_log")
     @patch("nextflow.command.get_process_executions")
     @patch("nextflow.command.Execution")
-    def test_can_get_execution(self, mock_ex, mock_proc, mock_fin, mock_start, mock_file):
-        mock_file.side_effect = [
-            "log text [xx_yy]", "ok", "bad", "9"
-        ]
-        mock_ex.return_value = Mock(process_executions=[Mock(execution=None), Mock(execution=None)])
-        execution = get_execution("/ex", "a=b; nf run >/out/stdout.txt 2>/out/xxx/stderr.txt")
-        self.assertEqual([c[0] for c in mock_file.call_args_list], [
-            (os.path.join("/ex", ".nextflow.log"),),
-            (os.path.join("/ex", "stdout.txt"),),
-            (os.path.join("/ex", "stderr.txt"),),
-            (os.path.join("/ex", "rc.txt"),),
-        ])
+    def test_can_get_execution(
+        self, mock_ex, mock_proc, mock_fin, mock_start, mock_file
+    ):
+        mock_file.side_effect = ["log text [xx_yy]", "ok", "bad", "9"]
+        mock_ex.return_value = Mock(
+            process_executions=[Mock(execution=None), Mock(execution=None)]
+        )
+        execution = get_execution(
+            "/ex", "a=b; nf run >/out/stdout.txt 2>/out/xxx/stderr.txt"
+        )
+        self.assertEqual(
+            [c[0] for c in mock_file.call_args_list],
+            [
+                (os.path.join("/ex", ".nextflow.log"),),
+                (os.path.join("/ex", "stdout.txt"),),
+                (os.path.join("/ex", "stderr.txt"),),
+                (os.path.join("/ex", "rc.txt"),),
+            ],
+        )
         mock_start.assert_called_with("log text [xx_yy]")
         mock_fin.assert_called_with("log text [xx_yy]")
         mock_proc.assert_called_with("log text [xx_yy]", "/ex")
@@ -291,29 +387,31 @@ class GetExecutionTests(TestCase):
         self.assertEqual(execution, mock_ex.return_value)
         for proc in mock_ex.return_value.process_executions:
             self.assertIs(proc.execution, mock_ex.return_value)
-    
 
     @patch("nextflow.command.get_file_text")
     @patch("nextflow.command.get_started_from_log")
     @patch("nextflow.command.get_finished_from_log")
     @patch("nextflow.command.get_process_executions")
     @patch("nextflow.command.Execution")
-    def test_can_get_no_execution(self, mock_ex, mock_proc, mock_fin, mock_start, mock_file):
+    def test_can_get_no_execution(
+        self, mock_ex, mock_proc, mock_fin, mock_start, mock_file
+    ):
         mock_file.return_value = None
-       
+
         self.assertIsNone(get_execution("/ex", "nf run >stdout.txt 2>stderr.txt"))
-        self.assertEqual([c[0] for c in mock_file.call_args_list], [
-            (os.path.join("/ex", ".nextflow.log"),),
-        ])
+        self.assertEqual(
+            [c[0] for c in mock_file.call_args_list],
+            [
+                (os.path.join("/ex", ".nextflow.log"),),
+            ],
+        )
         self.assertFalse(mock_start.called)
         self.assertFalse(mock_fin.called)
         self.assertFalse(mock_proc.called)
         self.assertFalse(mock_ex.called)
 
 
-
 class GetProcessExecutionsTests(TestCase):
-
     @patch("nextflow.command.get_process_ids_to_paths")
     @patch("nextflow.command.get_process_execution")
     def test_can_get_process_executions(self, mock_proc, mock_ids):
@@ -322,37 +420,52 @@ class GetProcessExecutionsTests(TestCase):
             "ab/123456": "/ex/ab/123456aa",
             "cd/789012": "/ex/cd/789012bb",
         }
+        process_info = {
+            "ab/123456": {
+                "name": None,
+                "start": None,
+                "end": None,
+                "status": "-",
+            },
+            "cd/789012": {
+                "name": None,
+                "start": None,
+                "end": None,
+                "status": "-",
+            },
+        }
         process_executions = get_process_executions(log, "/ex")
         mock_ids.assert_called_with(["ab/123456", "cd/789012"], "/ex")
-        self.assertEqual([c[0] for c in mock_proc.call_args_list], [
-            ("ab/123456", "/ex/ab/123456aa", log, "/ex"),
-            ("cd/789012", "/ex/cd/789012bb", log, "/ex"),
-        ])
-        self.assertEqual(process_executions, [mock_proc.return_value, mock_proc.return_value])
-
+        self.assertEqual(
+            [c[0] for c in mock_proc.call_args_list],
+            [
+                ("ab/123456", "/ex/ab/123456aa", process_info, "/ex"),
+                ("cd/789012", "/ex/cd/789012bb", process_info, "/ex"),
+            ],
+        )
+        self.assertEqual(
+            process_executions, [mock_proc.return_value, mock_proc.return_value]
+        )
 
 
 class GetProcessExecutionTests(TestCase):
-
     @patch("nextflow.command.get_file_text")
-    @patch("nextflow.command.get_process_name_from_log")
-    @patch("nextflow.command.get_process_start_from_log")
-    @patch("nextflow.command.get_process_end_from_log")
-    @patch("nextflow.command.get_process_status_from_log")
     @patch("nextflow.command.ProcessExecution")
-    def test_can_get_process_execution(self, mock_proc, mock_status, mock_end, mock_start, mock_name, mock_file):
-        mock_name.return_value = "PROC (123)"
-        mock_file.side_effect = [
-            "ok", "bad", "9", "$"
-        ]
-        process_execution = get_process_execution("xx_yy", "aa/bb", "log text", "/ex")
-        self.assertEqual([c[0] for c in mock_file.call_args_list], [
-            (os.path.join("/ex", "work", "aa/bb", ".command.out"),),
-            (os.path.join("/ex", "work", "aa/bb", ".command.err"),),
-            (os.path.join("/ex", "work", "aa/bb", ".exitcode"),),
-            (os.path.join("/ex", "work", "aa/bb", ".command.sh"),),
-        ])
-        mock_name.assert_called_with("log text", "xx_yy")
+    def test_can_get_process_execution(self, mock_proc, mock_file):
+        mock_file.side_effect = ["ok", "bad", "9", "$"]
+        process_info = {
+            "xx_yy": {"name": "PROC (123)", "start": None, "end": None, "status": "-"}
+        }
+        process_execution = get_process_execution("xx_yy", "aa/bb", process_info, "/ex")
+        self.assertEqual(
+            [c[0] for c in mock_file.call_args_list],
+            [
+                (os.path.join("/ex", "work", "aa/bb", ".command.out"),),
+                (os.path.join("/ex", "work", "aa/bb", ".command.err"),),
+                (os.path.join("/ex", "work", "aa/bb", ".exitcode"),),
+                (os.path.join("/ex", "work", "aa/bb", ".command.sh"),),
+            ],
+        )
         mock_proc.assert_called_with(
             identifier="xx_yy",
             name="PROC (123)",
@@ -362,27 +475,21 @@ class GetProcessExecutionTests(TestCase):
             stderr="bad",
             return_code="9",
             bash="$",
-            started=mock_start.return_value,
-            finished=mock_end.return_value,
-            status=mock_status.return_value,
+            started=(None,),
+            finished=(None,),
+            status=("-",),
         )
         self.assertEqual(process_execution, mock_proc.return_value)
-    
 
     @patch("nextflow.command.get_file_text")
-    @patch("nextflow.command.get_process_name_from_log")
-    @patch("nextflow.command.get_process_start_from_log")
-    @patch("nextflow.command.get_process_end_from_log")
-    @patch("nextflow.command.get_process_status_from_log")
     @patch("nextflow.command.ProcessExecution")
-    def test_can_get_process_execution_without_path(self, mock_proc, mock_status, mock_end, mock_start, mock_name, mock_file):
-        mock_name.return_value = "PROC 1"
-        mock_file.side_effect = [
-            "ok", "bad", "9", "$"
-        ]
-        process_execution = get_process_execution("xx_yy", "", "log text", "/ex")
+    def test_can_get_process_execution_without_path(self, mock_proc, mock_file):
+        mock_file.side_effect = ["ok", "bad", "9", "$"]
+        process_info = {
+            "xx_yy": {"name": "PROC 1", "start": None, "end": None, "status": "-"}
+        }
+        process_execution = get_process_execution("xx_yy", "", process_info, "/ex")
         self.assertEqual([c[0] for c in mock_file.call_args_list], [])
-        mock_name.assert_called_with("log text", "xx_yy")
         mock_proc.assert_called_with(
             identifier="xx_yy",
             name="PROC 1",
@@ -392,11 +499,8 @@ class GetProcessExecutionTests(TestCase):
             stderr="",
             return_code="",
             bash="",
-            started=mock_start.return_value,
-            finished=mock_end.return_value,
-            status=mock_status.return_value,
+            started=(None,),
+            finished=(None,),
+            status=("-",),
         )
         self.assertEqual(process_execution, mock_proc.return_value)
-        
-        
-       


### PR DESCRIPTION
In order to determine the status, the nextflow wrapper opens the `.nextflow.log` file and parses out the name, start time, finish time, and exit code for a given nextflow process identifier, which corresponds to a job on AWS Batch. It does this on every polling loop.

The crux of the problem is that it is parsing the log 4 times for _every_ identifier. For our larger analyses, this can literally be thousands of identifiers. Not only that, but the more identifiers we have, the larger the log is and the longer it takes to parse. This exponentially blows up the processing time for each polling cycle. From testing with CITN-07:
```
SAMPLES_FROM_GATING_SET job - polling cycle: 0.005s
COMPENSATE jobs (hundreds) - polling cycle: 9.572s
TIME_FILTER jobs (hundreds) - polling cycle: 24.334s
MARGINS jobs (hundreds) - polling cycle: 115.022s
Around this time it gets totally bogged down. AWS batch completes, but the polling takes like 30 minutes to cycle through and detect the status.
```

Solution in this PR is to do 1 pass of the log file per polling cycle and collect the information for every process identifier found in the logs into a dictionary. This maintains a consistent <1s processing time for the polling cycle no matter how many identifiers.